### PR TITLE
modify exporting the GOBOOK ENV:

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 2) 打开 ~/.bashrc，加入： 
 
-    export $GOBOOK=~/gobook  #假设代码在 ~/gobook 下
+    export GOBOOK=~/gobook  #假设代码在 ~/gobook 下
     source $GOBOOK/env.sh
 
 3) 保存 ~/.bashrc，并 source 之


### PR DESCRIPTION
modify export the GOBOOK ENV:  remove the `$` in the below command：

```
export $GOBOOK=~/gobook  #假设代码在 ~/gobook 下
```

or it will report "bad assignment"
